### PR TITLE
Fix adding images using local path

### DIFF
--- a/src/Commands/Common/Entity/Images/AddImageCommand.cs
+++ b/src/Commands/Common/Entity/Images/AddImageCommand.cs
@@ -57,7 +57,7 @@ public abstract class AddImageCommand : Command
         Logger.LogInformation($"  {nameof(imageFile.GetType)}: {imageFile.GetType()}");
 
         await entity.AddImageAsync(imageFile, imageId ?? imageFile.Id, imageName, cancellationToken);
-        var addedImage = await entity.GetImageFilesAsync(cancellationToken).FirstAsync(x=> x.Id == imageId || x.Name == imageName, cancellationToken: cancellationToken);
+        var addedImage = await entity.GetImageFilesAsync(cancellationToken).FirstAsync(x=> x.Id == (imageId ?? imageFile.Id) || x.Name == imageName, cancellationToken: cancellationToken);
         Logger.LogInformation($"Added file:");
         Logger.LogInformation($"- {nameof(addedImage.Id)}: {addedImage.Id}");
         Logger.LogInformation($"  {nameof(addedImage.Name)}: {addedImage.Name}");


### PR DESCRIPTION
## Background/Problem

Originally reported by @yoshiask in the Windows App Community [`#community-infra`->`Kermit coordination`](https://discord.com/channels/372137812037730304/1394076110014251058/1410002285072748625) thread: 

As an aside, I'm having issues with adding an image to a user:
```
.\WindowsAppCommunity.CommandLine.exe user images add --user-id k51qzi5uqu5dlcxnaakr3yg32iknb9lz8j0ydyglzldfkgge0otv9gyyy9douu --image-path "C:\Users\jjask\Pictures\Iskhyron.jpeg"
+118ms AddImageCommand InvokeAsync  [Information]  Getting modifiable entity
+314ms AddImageCommand InvokeAsync  [Information]  Got Id: k51qzi5uqu5dlcxnaakr3yg32iknb9lz8j0ydyglzldfkgge0otv9gyyy9douu
+314ms AddImageCommand InvokeAsync  [Information]  Input file:
+314ms AddImageCommand InvokeAsync  [Information]  - Id: C:\Users\jjask\Pictures\Iskhyron.jpeg
+315ms AddImageCommand InvokeAsync  [Information]    Name: Iskhyron.jpeg
+315ms AddImageCommand InvokeAsync  [Information]    GetType: OwlCore.Storage.System.IO.ContentAddressedSystemFile
Unhandled exception: System.InvalidOperationException: Source sequence doesn't contain any elements.
   at System.Linq.AsyncEnumerable.<FirstAsync>g__Core|88_0[TSource](IAsyncEnumerable`1 source, Func`2 predicate, CancellationToken cancellationToken) in /_/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/First.cs:line 60
   at WindowsAppCommunity.CommandLine.Common.Images.AddImageCommand.InvokeAsync(String repo, String id, String imagePath, String imageId, String imageName) in C:\Users\jjask\source\repos\WindowsAppCommunity\WindowsAppCommunity.CommandLine\src\Commands\Common\Entity\Images\AddImageCommand.cs:line 60
```

## Solution

Fix image retrieval logic in AddImageCommand to handle null imageId correctly.

