### PR TITLE
feat(cli): add delete commands for user, project, publisher

### DIFF
--- a/src/Commands/Project/WacsdkProjectCommands.cs
+++ b/src/Commands/Project/WacsdkProjectCommands.cs
@@ -53,6 +53,7 @@ public class WacsdkProjectCommands : Command
         AddCommand(new WacsdkProjectGetCommand(config, repoOption));
         AddCommand(new WacsdkProjectCreateCommand(config, repoOption, nameOption, descriptionOption));
         AddCommand(new WacsdkProjectListCommand(config, repoOption));
+        AddCommand(new WacsdkProjectDeleteCommand(config, repoOption));
 
         // Add entity property management commands
         AddCommand(new EntityNameCommand(config, repoOption, projectIdOption, valueOption));
@@ -60,14 +61,14 @@ public class WacsdkProjectCommands : Command
         AddCommand(new EntityExtendedDescription(config, repoOption, projectIdOption, valueOption));
         AddCommand(new EntityIsUnlistedCommand(config, repoOption, projectIdOption, boolValueOption));
         AddCommand(new EntityForgetMeCommand(config, repoOption, projectIdOption, nullableBoolValueOption));
-        
+
         // Add collection management commands
         AddCommand(new ConnectionsCommand(config, repoOption, projectIdOption, connectionIdOption, connectionValueOption));
         AddCommand(new EntityImagesCommand(config, repoOption, projectIdOption, imagePathOption, optionalImageIdOption, requiredImageIdOption, imageNameOption));
         AddCommand(new LinksCommand(config, repoOption, projectIdOption, linkIdOption, nameOption, urlOption, descriptionOption));
         AddCommand(new UserRolesCommand(config, repoOption, projectIdOption, userIdOption, roleIdOption, roleNameOption, roleDescriptionOption));
         AddCommand(new AccentColorCommand(config, repoOption, projectIdOption, colorOption));
-        
+
         // Add project-specific commands
         AddCommand(new CategoryCommand(config, repoOption, projectIdOption, categoryOption));
         AddCommand(new FeaturesCommand(config, repoOption, projectIdOption, featureOption));

--- a/src/Commands/Project/WacsdkProjectDeleteCommand.cs
+++ b/src/Commands/Project/WacsdkProjectDeleteCommand.cs
@@ -1,0 +1,63 @@
+using OwlCore.Diagnostics;
+using OwlCore.Storage;
+using System.CommandLine;
+using WindowsAppCommunity.Sdk.Nomad;
+
+namespace WindowsAppCommunity.CommandLine.Project
+{
+    /// <summary>
+    /// Command to delete an existing project.
+    /// </summary>
+    public class WacsdkProjectDeleteCommand : Command
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WacsdkProjectDeleteCommand"/> class.
+        /// </summary>
+        public WacsdkProjectDeleteCommand(WacsdkCommandConfig config, Option<string> repoOption)
+            : base(name: "delete", description: "Deletes a project.")
+        {
+            var projectIdOption = new Option<string>(
+                name: "--project-id",
+                description: "The ID of the project to delete.")
+            {
+                IsRequired = true
+            };
+
+            AddOption(repoOption);
+            AddOption(projectIdOption);
+            this.SetHandler(InvokeAsync, repoOption, projectIdOption);
+
+            Config = config;
+        }
+
+        /// <summary>
+        /// Shared command configuration.
+        /// </summary>
+        public WacsdkCommandConfig Config { get; }
+
+        /// <summary>
+        /// Handles the command.
+        /// </summary>
+        public async Task InvokeAsync(string repoId, string projectId)
+        {
+            var thisRepoStorage = (IModifiableFolder)await Config.RepositoryStorage.CreateFolderAsync(repoId, overwrite: false);
+
+            Logger.LogInformation($"Getting repo store with ID {repoId} at {thisRepoStorage.GetType().Name} {thisRepoStorage.Id}");
+            var repoSettings = new WacsdkNomadSettings(thisRepoStorage);
+            await repoSettings.LoadAsync(Config.CancellationToken);
+
+            var repositoryContainer = new RepositoryContainer(Config.KuboOptions, Config.Client, repoSettings.ManagedKeys, repoSettings.ManagedUserConfigs, repoSettings.ManagedProjectConfigs, repoSettings.ManagedPublisherConfigs);
+
+            Logger.LogInformation($"Getting project {projectId}");
+            var project = (ModifiableProject)await repositoryContainer.ProjectRepository.GetAsync(projectId, Config.CancellationToken);
+
+            Logger.LogInformation($"Deleting project {projectId}");
+            await repositoryContainer.ProjectRepository.DeleteAsync(project, Config.CancellationToken);
+
+            Logger.LogInformation($"Saving repository changes");
+            await repoSettings.SaveAsync(Config.CancellationToken);
+
+            Logger.LogInformation($"Deleted project {projectId}");
+        }
+    }
+}

--- a/src/Commands/Publisher/WacsdkPublisherCommands.cs
+++ b/src/Commands/Publisher/WacsdkPublisherCommands.cs
@@ -57,6 +57,7 @@ namespace WindowsAppCommunity.CommandLine.Publisher
             AddCommand(new WacsdkPublisherGetCommand(config, repoOption));
             AddCommand(new WacsdkPublisherCreateCommand(config, repoOption));
             AddCommand(new WacsdkPublisherListCommand(config, repoOption));
+            AddCommand(new WacsdkPublisherDeleteCommand(config, repoOption));
 
             // Add entity property management commands
             AddCommand(new EntityNameCommand(config, repoOption, publisherIdOption, valueOption));
@@ -64,7 +65,7 @@ namespace WindowsAppCommunity.CommandLine.Publisher
             AddCommand(new EntityExtendedDescription(config, repoOption, publisherIdOption, valueOption));
             AddCommand(new EntityIsUnlistedCommand(config, repoOption, publisherIdOption, boolValueOption));
             AddCommand(new EntityForgetMeCommand(config, repoOption, publisherIdOption, nullableBoolValueOption));
-            
+
             // Add collection management commands
             AddCommand(new ConnectionsCommand(config, repoOption, publisherIdOption, connectionIdOption, connectionValueOption));
             AddCommand(new EntityImagesCommand(config, repoOption, publisherIdOption, imagePathOption, requiredImageIdOption, optionalImageIdOption, imageNameOption));

--- a/src/Commands/Publisher/WacsdkPublisherDeleteCommand.cs
+++ b/src/Commands/Publisher/WacsdkPublisherDeleteCommand.cs
@@ -1,0 +1,63 @@
+using OwlCore.Diagnostics;
+using OwlCore.Storage;
+using System.CommandLine;
+using WindowsAppCommunity.Sdk.Nomad;
+
+namespace WindowsAppCommunity.CommandLine.Publisher
+{
+    /// <summary>
+    /// Command to delete an existing publisher.
+    /// </summary>
+    public class WacsdkPublisherDeleteCommand : Command
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WacsdkPublisherDeleteCommand"/> class.
+        /// </summary>
+        public WacsdkPublisherDeleteCommand(WacsdkCommandConfig config, Option<string> repoOption)
+            : base(name: "delete", description: "Deletes a publisher.")
+        {
+            var publisherIdOption = new Option<string>(
+                name: "--publisher-id",
+                description: "The ID of the publisher to delete.")
+            {
+                IsRequired = true
+            };
+
+            AddOption(repoOption);
+            AddOption(publisherIdOption);
+            this.SetHandler(InvokeAsync, repoOption, publisherIdOption);
+
+            Config = config;
+        }
+
+        /// <summary>
+        /// Shared command configuration.
+        /// </summary>
+        public WacsdkCommandConfig Config { get; }
+
+        /// <summary>
+        /// Handles the command.
+        /// </summary>
+        public async Task InvokeAsync(string repoId, string publisherId)
+        {
+            var thisRepoStorage = (IModifiableFolder)await Config.RepositoryStorage.CreateFolderAsync(repoId, overwrite: false);
+
+            Logger.LogInformation($"Getting repo store with ID {repoId} at {thisRepoStorage.GetType().Name} {thisRepoStorage.Id}");
+            var repoSettings = new WacsdkNomadSettings(thisRepoStorage);
+            await repoSettings.LoadAsync(Config.CancellationToken);
+
+            var repositoryContainer = new RepositoryContainer(Config.KuboOptions, Config.Client, repoSettings.ManagedKeys, repoSettings.ManagedUserConfigs, repoSettings.ManagedProjectConfigs, repoSettings.ManagedPublisherConfigs);
+
+            Logger.LogInformation($"Getting publisher {publisherId}");
+            var publisher = (ModifiablePublisher)await repositoryContainer.PublisherRepository.GetAsync(publisherId, Config.CancellationToken);
+
+            Logger.LogInformation($"Deleting publisher {publisherId}");
+            await repositoryContainer.PublisherRepository.DeleteAsync(publisher, Config.CancellationToken);
+
+            Logger.LogInformation($"Saving repository changes");
+            await repoSettings.SaveAsync(Config.CancellationToken);
+
+            Logger.LogInformation($"Deleted publisher {publisherId}");
+        }
+    }
+}

--- a/src/Commands/User/WacsdkUserCommands.cs
+++ b/src/Commands/User/WacsdkUserCommands.cs
@@ -44,20 +44,21 @@ public class WacsdkUserCommands : Command
         var roleIdOption = new Option<string>("--role-id", "The ID of the role.");
         var roleNameOption = new Option<string>("--role-name", "The name of the role.");
         var roleDescriptionOption = new Option<string>("--role-description", "The description of the role.");
-        
-        
+
+
         // Add high-level user operations
         AddCommand(new WacsdkUserGetCommand(config, repoOption));
         AddCommand(new WacsdkUserCreateCommand(config, repoOption, nameOption, descriptionOption));
-        AddCommand(new WacsdkUserListCommand(config, repoOption)); 
-        
+        AddCommand(new WacsdkUserListCommand(config, repoOption));
+        AddCommand(new WacsdkUserDeleteCommand(config, repoOption));
+
         // Add entity property management commands
         AddCommand(new EntityNameCommand(config, repoOption, userIdOption, valueOption));
         AddCommand(new EntityDescription(config, repoOption, userIdOption, valueOption));
         AddCommand(new EntityExtendedDescription(config, repoOption, userIdOption, valueOption));
         AddCommand(new EntityIsUnlistedCommand(config, repoOption, userIdOption, boolValueOption));
         AddCommand(new EntityForgetMeCommand(config, repoOption, userIdOption, nullableBoolValueOption));
-        
+
         // Add collection management commands
         AddCommand(new ConnectionsCommand(config, repoOption, userIdOption, connectionIdOption, connectionValueOption));
         AddCommand(new EntityImagesCommand(config, repoOption, userIdOption, imagePathOption, imageNameOption, optionalImageIdOption, requiredImageIdOption));

--- a/src/Commands/User/WacsdkUserDeleteCommand.cs
+++ b/src/Commands/User/WacsdkUserDeleteCommand.cs
@@ -1,0 +1,64 @@
+using OwlCore.Diagnostics;
+using OwlCore.Storage;
+using System.CommandLine;
+using WindowsAppCommunity.Sdk.Nomad;
+
+namespace WindowsAppCommunity.CommandLine.User
+{
+    /// <summary>
+    /// Command to delete an existing user.
+    /// </summary>
+    public class WacsdkUserDeleteCommand : Command
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WacsdkUserDeleteCommand"/> class.
+        /// </summary>
+        public WacsdkUserDeleteCommand(WacsdkCommandConfig config, Option<string> repoOption)
+            : base(name: "delete", description: "Deletes a user.")
+        {
+            var userIdOption = new Option<string>(
+                name: "--user-id",
+                description: "The ID of the user to delete.")
+            {
+                IsRequired = true
+            };
+
+            AddOption(repoOption);
+            AddOption(userIdOption);
+
+            this.SetHandler(InvokeAsync, repoOption, userIdOption);
+
+            Config = config;
+        }
+
+        /// <summary>
+        /// Shared command configuration.
+        /// </summary>
+        public WacsdkCommandConfig Config { get; }
+
+        /// <summary>
+        /// Handles the command.
+        /// </summary>
+        public async Task InvokeAsync(string repoId, string userId)
+        {
+            var thisRepoStorage = (IModifiableFolder)await Config.RepositoryStorage.CreateFolderAsync(repoId, overwrite: false);
+
+            Logger.LogInformation($"Getting repo store with ID {repoId} at {thisRepoStorage.GetType().Name} {thisRepoStorage.Id}");
+            var repoSettings = new WacsdkNomadSettings(thisRepoStorage);
+            await repoSettings.LoadAsync(Config.CancellationToken);
+
+            var repositoryContainer = new RepositoryContainer(Config.KuboOptions, Config.Client, repoSettings.ManagedKeys, repoSettings.ManagedUserConfigs, repoSettings.ManagedProjectConfigs, repoSettings.ManagedPublisherConfigs);
+
+            Logger.LogInformation($"Getting user {userId}");
+            var user = (ModifiableUser)await repositoryContainer.UserRepository.GetAsync(userId, Config.CancellationToken);
+
+            Logger.LogInformation($"Deleting user {userId}");
+            await repositoryContainer.UserRepository.DeleteAsync(user, Config.CancellationToken);
+
+            Logger.LogInformation($"Saving repository changes");
+            await repoSettings.SaveAsync(Config.CancellationToken);
+
+            Logger.LogInformation($"Deleted user {userId}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add first-class delete commands for the three core entities (user, project, publisher) to allow targeted cleanup and parity with existing create/get/list flows.

## Motivation

- Provide a focused delete operation to remove a problematic entity without deleting the entire repo.
- Feature parity: create/get/list existed for all three entities; delete was missing.

## What’s in this PR

- New CLI commands:
  - user delete — `wacsdk user delete --repo <repo-id> --user-id <ipns-id>`
  - project delete — `wacsdk project delete --repo <repo-id> --project-id <ipns-id>`
  - publisher delete — `wacsdk publisher delete --repo <repo-id> --publisher-id <ipns-id>`
- Commands are registered within their respective command groups.
- Calls through the SDK repositories to resolve a modifiable instance and invoke `DeleteAsync`, then saves repo settings.
- XML docs added to satisfy WarningsAsErrors.

## Implementation notes

- Repositories: `RepositoryContainer` is used to compose interdependent repositories.
- Delete flow: `GetAsync(id)` → cast to modifiable type → `Repository.DeleteAsync(modifiable, ct)` → `repoSettings.SaveAsync(ct)`.
- No manual cleanup fallback logic is included; the commands are intentionally straightforward.

## Usage examples

```pwsh
wacsdk user delete --repo default --user-id k51qzi5uqu5dl...
wacsdk project delete --repo default --project-id k51qzi5uqu5ab...
wacsdk publisher delete --repo default --publisher-id k51qzi5uqu5xy...
```

## Testing / Verification

- Built locally with warnings-as-errors; added XML comments to new public members.
- Manual smoke tests:
  - Create an entity, then delete it; list no longer shows the entity.
  - Delete logs indicate key removal via the repository base logic and settings save completes.

## Breaking changes

- None. Adds new commands only.

## Future work

- Consider a soft-delete flag (e.g., unlist then purge) if user workflows need it.
- Add unit/integration coverage for delete flows if a test harness is extended for IPNS key lifecycle.

## Checklist

- [x] Commands added and wired into command groups
- [x] Build passes locally with warnings-as-errors
- [x] Minimal logs and help text added

## Branch

`feat/entity-delete-commands`
